### PR TITLE
Remove ambiguous default replacement

### DIFF
--- a/AutoSpell.sublime-settings
+++ b/AutoSpell.sublime-settings
@@ -11,7 +11,6 @@
   ],
   "default_replacements": {
     "remvoe": "remove",
-    "fakse": "fake",
     "karam": "karma",
     "resovle": "resolve",
     "adn": "and",


### PR DESCRIPTION
IMHO I think the "fakse" => "fake" default replacement is not generic enough to be a default setting. For many developers, "fakse" can also be very often a typing error for the "false" keyword. Maybe even more than "fake". I know we can overwrite this value in our user settings, I just suggest thinking about this replacement in package defaults settings. Thanks.